### PR TITLE
fix: update CORSmiddleware to include PUT method in allowed methods

### DIFF
--- a/backend/internal/handlers/middlewares.go
+++ b/backend/internal/handlers/middlewares.go
@@ -79,7 +79,7 @@ func CORSmiddleware(frontendUrls []string) gin.HandlerFunc {
 			}
 		}
 
-		ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
+		ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, PUT, POST, PATCH, DELETE, OPTIONS")
 		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 		ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "false")
 		ctx.Writer.Header().Set("Access-Control-Max-Age", "86400")


### PR DESCRIPTION
This pull request makes a minor update to the allowed HTTP methods in the CORS middleware. The change adds support for the `PUT` method, ensuring that cross-origin requests using `PUT` are properly handled.

* Added `PUT` to the list of allowed HTTP methods in the CORS headers in `middlewares.go`, enabling cross-origin `PUT` requests.