### PR TITLE
add user details to the login handler response

### DIFF
--- a/backend/internal/handlers/users.go
+++ b/backend/internal/handlers/users.go
@@ -282,7 +282,7 @@ func (s *Server) login(ctx *gin.Context) {
 	// 	true,
 	// )
 
-	_, err = s.repo.UserRepository.UpdateUser(ctx, &repository.UpdateUser{
+	updatedUser, err := s.repo.UserRepository.UpdateUser(ctx, &repository.UpdateUser{
 		ID:           user.ID,
 		RefreshToken: &refreshToken,
 	})
@@ -295,6 +295,7 @@ func (s *Server) login(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{
 		"access_token":  accessToken,
 		"refresh_token": refreshToken,
+		"user":          updatedUser,
 	})
 }
 


### PR DESCRIPTION
This pull request makes a minor enhancement to the login handler by returning the updated user object in the login response. This allows clients to receive the latest user information immediately after login.

* The `login` handler now includes the updated user object in the JSON response, providing clients with up-to-date user data after a successful login. [[1]](diffhunk://#diff-f8edc97f85503fc6bcd0c7890a9916a55d38917d1007cc6a4fbafc5c2e2f120aL285-R285) [[2]](diffhunk://#diff-f8edc97f85503fc6bcd0c7890a9916a55d38917d1007cc6a4fbafc5c2e2f120aR298)