### PR TITLE
feat: remove debug logging from ProductService constructor

### DIFF
--- a/src/app/shared/services/product.service.ts
+++ b/src/app/shared/services/product.service.ts
@@ -57,9 +57,6 @@ export class ProductService {
     this.fecthCategories().subscribe();
     this.fetchAddOns().subscribe();
     this.fetchMessageCards().subscribe();
-    effect(() => {
-      console.log('productBaseApiUrl', this.productBaseApiUrl());
-    });
   }
 
   getAddOns() {


### PR DESCRIPTION
This pull request makes a minor change to the initialization logic in the `ProductService` class. It removes a debug logging effect that printed the value of `productBaseApiUrl` to the console.

* Removed a `console.log` effect that logged `productBaseApiUrl` during service initialization in `product.service.ts`.